### PR TITLE
fix(links): use public GCS URL for resume

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -130,7 +130,7 @@ export default function About() {
                     Get In Touch
                   </button>
                   <a
-                    href="https://storage.cloud.google.com/portfolio-c973b.firebasestorage.app/resumes/AI_Native_Resume.pdf?authuser=1"
+                    href="https://storage.googleapis.com/portfolio-c973b.firebasestorage.app/resumes/AI_Native_Resume.pdf"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 px-6 py-3 rounded-lg font-medium transition-colors"

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -43,7 +43,7 @@ const Sidebar = ({ onContactClick }: SidebarProps) => {
   const socialLinks = [
     { name: "GitHub", icon: Github, href: "https://github.com/albertshih3" },
     { name: "LinkedIn", icon: Linkedin, href: "https://linkedin.com/in/albertshih3" },
-    { name: "Resume", icon: ExternalLink, href: "https://storage.cloud.google.com/portfolio-c973b.firebasestorage.app/resumes/AI_Native_Resume.pdf?authuser=1" },
+    { name: "Resume", icon: ExternalLink, href: "https://storage.googleapis.com/portfolio-c973b.firebasestorage.app/resumes/AI_Native_Resume.pdf" },
   ];
 
   return (


### PR DESCRIPTION
- Switch resume links to storage.googleapis.com in About and Sidebar
- Remove authuser param for publicly accessible, shareable URL
- Ensure consistent resume link across site

Changes to be committed:
	modified:   src/app/about/page.tsx
	modified:   src/components/sidebar/sidebar.tsx